### PR TITLE
Add gnu source

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "ess-view.el")


### PR DESCRIPTION
Because let-alist which is dependency of flycheck is hosted on GNU ELPA .
