### PR TITLE
[fix] Needs more quotes these days

### DIFF
--- a/ess-view.el
+++ b/ess-view.el
@@ -256,8 +256,8 @@ If SAVE is t, it also saves back the result."
         (setq ess-view-oggetto (ess-read-object-name "name of R object:"))
         (setq ess-view-oggetto (substring-no-properties (car ess-view-oggetto)))
         (cond
-         ((ess-boolean-command (concat "exists(" ess-view-oggetto ")\n"))
-          (message "The object does not exists"))
+         ((not (ess-boolean-command (concat "exists(\"" ess-view-oggetto "\")\n")))
+          (message "The object does not exist"))
          ((ess-boolean-command (concat "is.vector(" ess-view-oggetto ")\n"))
           (ess-view-print-vector ess-view-oggetto))
          ((ess-boolean-command (concat "is.data.frame(" ess-view-oggetto ")\n"))

--- a/ess-view.el
+++ b/ess-view.el
@@ -126,7 +126,7 @@ copy of the passed object which is used to create the temporary .csv file."
     ;; has the same name of our random generated 20-char string,
     ;; but just to be sure, we run this cycle recursively
     ;; until we find an environment name which does not exist yet
-    (if (ess-boolean-command (concat "is.environment(" nome-env ")\n"))
+    (if (ess-boolean-command (concat "is.environment(\"" nome-env "\")\n"))
         (ess-view-create-env))
     nome-env))
 


### PR DESCRIPTION
- Quote the strings passed to R's `exists()` and `is.environment()`
- Fix a nearby typo

Tested with R version 4.4.2 (2024-10-31) “Pile of Leaves” on Mac OS X Sequoia 15.4 (24E248), Intel processor.
